### PR TITLE
Public the Menu Parameters set API

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemParameters.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/SystemParameters.cs
@@ -1018,6 +1018,14 @@ namespace System.Windows
                 }
                 return _menuDropAlignment;
             }
+            set
+            {
+                lock (_cacheValid)
+                {
+                    _cacheValid[(int)CacheSlot.MenuDropAlignment] = true;
+                    _menuDropAlignment = value;
+                }
+            }
         }
 
         /// <summary>
@@ -1045,6 +1053,14 @@ namespace System.Windows
                 }
 
                 return _menuFade;
+            }
+            set
+            {
+                lock (_cacheValid)
+                {
+                    _cacheValid[(int)CacheSlot.MenuFade] = true;
+                    _menuFade = value;
+                }
             }
         }
 
@@ -1074,6 +1090,14 @@ namespace System.Windows
                 }
 
                 return _menuShowDelay;
+            }
+            set
+            {
+                lock (_cacheValid)
+                {
+                    _cacheValid[(int)CacheSlot.MenuShowDelay] = true;
+                    _menuShowDelay = value;
+                }
             }
         }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/ref/PresentationFramework.cs
@@ -1563,15 +1563,15 @@ namespace System.Windows
         public static System.Windows.ResourceKey MenuCheckmarkHeightKey { get { throw null; } }
         public static double MenuCheckmarkWidth { get { throw null; } }
         public static System.Windows.ResourceKey MenuCheckmarkWidthKey { get { throw null; } }
-        public static bool MenuDropAlignment { get { throw null; } }
+        public static bool MenuDropAlignment { get { throw null; } set {} }
         public static System.Windows.ResourceKey MenuDropAlignmentKey { get { throw null; } }
-        public static bool MenuFade { get { throw null; } }
+        public static bool MenuFade { get { throw null; } set { } }
         public static System.Windows.ResourceKey MenuFadeKey { get { throw null; } }
         public static double MenuHeight { get { throw null; } }
         public static System.Windows.ResourceKey MenuHeightKey { get { throw null; } }
         public static System.Windows.Controls.Primitives.PopupAnimation MenuPopupAnimation { get { throw null; } }
         public static System.Windows.ResourceKey MenuPopupAnimationKey { get { throw null; } }
-        public static int MenuShowDelay { get { throw null; } }
+        public static int MenuShowDelay { get { throw null; } set { } }
         public static System.Windows.ResourceKey MenuShowDelayKey { get { throw null; } }
         public static double MenuWidth { get { throw null; } }
         public static System.Windows.ResourceKey MenuWidthKey { get { throw null; } }


### PR DESCRIPTION
We can ignore the System settings by the code:

            SystemParameters.StaticPropertyChanged += (sender, eventArgs) =>
            {
                SystemParameters.MenuDropAlignment = false;
            };

See https://github.com/dotnet/wpf/pull/6557

用来解决此问题： [Windows 通过编辑注册表设置左右手使用习惯更改 Popup 弹出位置](https://blog.lindexi.com/post/Windows-%E9%80%9A%E8%BF%87%E7%BC%96%E8%BE%91%E6%B3%A8%E5%86%8C%E8%A1%A8%E8%AE%BE%E7%BD%AE%E5%B7%A6%E5%8F%B3%E6%89%8B%E4%BD%BF%E7%94%A8%E4%B9%A0%E6%83%AF%E6%9B%B4%E6%94%B9-Popup-%E5%BC%B9%E5%87%BA%E4%BD%8D%E7%BD%AE.html )

原本需要使用反射，但是反射如果修改值过快，将因为没有设置到缓存而被重写，反射的代码没有调用 `_cacheValid[(int)CacheSlot.MenuDropAlignment] = true;` 的逻辑，尽管反射也能实现，但逻辑诡异

其他使用到这里的逻辑包含了 Popup 和 MenuItem 等，没有统一的禁用逻辑，因此开放此属性可以做到最小改动