### PR TITLE
Fix build error temporarily to unblock

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/CornerRadiusConverter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/CornerRadiusConverter.cs
@@ -176,7 +176,20 @@ namespace System.Windows
         {
             char listSeparator = TokenizerHelper.GetNumericListSeparator(cultureInfo);
 
-            return string.Create(cultureInfo, stackalloc char[64], $"{cr.TopLeft}{listSeparator}{cr.TopRight}{listSeparator}{cr.BottomRight}{listSeparator}{cr.BottomLeft}");
+            // Initial capacity [64] is an estimate based on a sum of:
+            // 48 = 4x double (twelve digits is generous for the range of values likely)
+            //  8 = 4x UnitType string (approx two characters)
+            //  4 = 4x separator characters
+            StringBuilder sb = new StringBuilder(64);
+
+            sb.Append(cr.TopLeft.ToString(cultureInfo));
+            sb.Append(listSeparator);
+            sb.Append(cr.TopRight.ToString(cultureInfo));
+            sb.Append(listSeparator);
+            sb.Append(cr.BottomRight.ToString(cultureInfo));
+            sb.Append(listSeparator);
+            sb.Append(cr.BottomLeft.ToString(cultureInfo));
+            return sb.ToString();
         }
 
         static internal CornerRadius FromString(string s, CultureInfo cultureInfo)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Input/KeyboardNavigation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Input/KeyboardNavigation.cs
@@ -903,7 +903,7 @@ namespace System.Windows.Input
                     // then we load the default FocusVisualStyle from ResourceDictionary.
                     if (fvs == FrameworkElement.DefaultFocusVisualStyle)
                     {
-                        fvs = SystemResources.FindResourceInternal(SystemParameters.FocusVisualStyleKey) as Style;
+                        fvs = FrameworkElement.FindResourceInternal(fe, fce: null, SystemParameters.FocusVisualStyleKey) as Style;
                     }
 
                     if (fvs != null)
@@ -930,7 +930,7 @@ namespace System.Windows.Input
                                 // then we load the default FocusVisualStyle from ResourceDictionary.
                                 if (fvs == FrameworkElement.DefaultFocusVisualStyle)
                                 {
-                                    fvs = SystemResources.FindResourceInternal(SystemParameters.FocusVisualStyleKey) as Style;
+                                    fvs = FrameworkElement.FindResourceInternal(fe: null, fce, SystemParameters.FocusVisualStyleKey) as Style;
                                 }
 
                                 if (fvs != null)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Input/KeyboardNavigation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Input/KeyboardNavigation.cs
@@ -802,7 +802,7 @@ namespace System.Windows.Input
             return GetParentUIElementFromContentElement(ce, ref ichParent);
         }
 
-        private static UIElement GetParentUIElementFromContentElement(ContentElement ce, ref IContentHost ichParent)
+        internal static UIElement GetParentUIElementFromContentElement(ContentElement ce, ref IContentHost ichParent)
         {
             if (ce == null)
                 return null;
@@ -903,7 +903,7 @@ namespace System.Windows.Input
                     // then we load the default FocusVisualStyle from ResourceDictionary.
                     if (fvs == FrameworkElement.DefaultFocusVisualStyle)
                     {
-                        fvs = FrameworkElement.FindResourceInternal(fe, fce: null, SystemParameters.FocusVisualStyleKey) as Style;
+                        fvs = SystemResources.FindResourceInternal(SystemParameters.FocusVisualStyleKey) as Style;
                     }
 
                     if (fvs != null)
@@ -930,7 +930,7 @@ namespace System.Windows.Input
                                 // then we load the default FocusVisualStyle from ResourceDictionary.
                                 if (fvs == FrameworkElement.DefaultFocusVisualStyle)
                                 {
-                                    fvs = FrameworkElement.FindResourceInternal(fe: null, fce, SystemParameters.FocusVisualStyleKey) as Style;
+                                    fvs = SystemResources.FindResourceInternal(SystemParameters.FocusVisualStyleKey) as Style;
                                 }
 
                                 if (fvs != null)

--- a/src/Microsoft.DotNet.Wpf/src/System.Printing/System.Printing.vcxproj
+++ b/src/Microsoft.DotNet.Wpf/src/System.Printing/System.Printing.vcxproj
@@ -233,4 +233,70 @@
       <SourceRevisionId Condition="'$(SourceRevisionId)' == ''">unknownrev</SourceRevisionId>
     </PropertyGroup>
   </Target>
+    <Target Name="CreateManifestResourceNames"
+          Condition="'@(EmbeddedResource)' != ''"
+          DependsOnTargets="$(CreateManifestResourceNamesDependsOn)"
+          >
+
+      <ItemGroup>
+             <_Temporary Remove="@(_Temporary)"/>
+      </ItemGroup>
+
+      <!-- Create manifest names for culture and non-culture Resx files, and for non-culture Non-Resx resources -->
+<CreateCSharpManifestResourceName
+      ResourceFiles="@(EmbeddedResource)"
+      RootNamespace="$(RootNamespace)"
+      Condition="'%(EmbeddedResource.ExcludedFromBuild)' != 'true' and '%(EmbeddedResource.ManifestResourceName)' == '' and ('%(EmbeddedResource.WithCulture)' == 'false' or '%(EmbeddedResource.Type)' == 'Resx')"
+      >
+
+             <Output TaskParameter="ResourceFilesWithManifestResourceNames" ItemName="_Temporary"/>
+
+</CreateCSharpManifestResourceName>
+
+      <!-- Create manifest names for all culture non-resx resources -->
+<CreateCSharpManifestResourceName
+      ResourceFiles="@(EmbeddedResource)"
+      RootNamespace="$(RootNamespace)"
+      PrependCultureAsDirectory="false"
+      Condition="'%(EmbeddedResource.ExcludedFromBuild)' != 'true' and '%(EmbeddedResource.ManifestResourceName)' == '' and '%(EmbeddedResource.WithCulture)' == 'true' and '%(EmbeddedResource.Type)' == 'Non-Resx'"
+      >
+
+             <Output TaskParameter="ResourceFilesWithManifestResourceNames" ItemName="_Temporary"/>
+
+</CreateCSharpManifestResourceName>
+      
+    <ItemGroup>
+             <EmbeddedResource Remove="@(EmbeddedResource)" Condition="'%(EmbeddedResource.ManifestResourceName)' == '' "/>
+             <EmbeddedResource Include="@(_Temporary)"/>
+      </ItemGroup>
+
+      <!-- create tlogs, but don't use the out if date items as all embedded resources should be passed to common msbuild targets-->
+      <ItemGroup>
+             <_Temporary Include ="@(EmbeddedResource)" Condition="'%(EmbeddedResource.ManifestResourceName)' != '' "/>
+             <_Temporary>
+             <OutputFile>$(TargetPath)</OutputFile>
+             <AdditionalInputs>$(ProjectPath)</AdditionalInputs>
+             </_Temporary>
+      </ItemGroup>
+
+      <GetOutOfDateItems
+      Condition                 ="'$(SelectedFiles)' == ''"
+      Sources                   ="@(_Temporary)"
+
+      OutputsMetadataName       ="OutputFile"
+      DependenciesMetadataName  ="AdditionalInputs"
+      CommandMetadataName       ="AdditionalInputs"
+
+      TLogDirectory             ="$(TLogLocation)"
+      TLogNamePrefix            ="ResGen"
+      TrackFileAccess           ="$(TrackFileAccess)"
+    >
+             <Output TaskParameter="OutOfDateSources" ItemName="_OutOfDateEmbeddedResource"/>
+      </GetOutOfDateItems>
+
+      <ItemGroup>
+             <_Temporary Remove="@(_Temporary)"/>
+            <_OutOfDateEmbeddedResource Remove="@(_OutOfDateEmbeddedResource)" />
+      </ItemGroup>
+</Target>
 </Project>


### PR DESCRIPTION
See https://github.com/dotnet/wpf/pull/6718

修复构建

修复 D:\a\dotnetCampus.CustomWpf\dotnetCampus.CustomWpf\src\Microsoft.DotNet.Wpf\src\PresentationFramework\System\Windows\CornerRadiusConverter.cs(179,68): error CS8773: Feature 'interpolated string handlers' is not available in C# 9.0. Please use language version 10.0 or greater.

由于挑拣了 304c0c6425f5d9525f479c0bdff3d9ed92f652cb 从而 Error: D:\a\dotnetCampus.CustomWpf\dotnetCampus.CustomWpf\src\Microsoft.DotNet.Wpf\src\PresentationFramework\System\Windows\Controls\PopupControlService.cs(844,66): error CS1501: No overload for method 'GetParentUIElementFromContentElement' takes 2 arguments