### PR TITLE
Fix get TransformToDevice in Stylus Input thread will throw the InvalidOperationException

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/StylusLogic.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Common/StylusLogic.cs
@@ -428,8 +428,7 @@ namespace System.Windows.Input
                 Type compositionTargetType = compositionTarget.GetType();
                 if (compositionTargetType == typeof(HwndTarget))
                 {
-                    var hwndTarget = (HwndTarget) compositionTarget;
-                    DpiScale2 currentDpiScale = hwndTarget.CurrentDpiScale;
+                    DpiScale2 currentDpiScale = compositionTarget.CurrentDpiScale;
                     toDevice.Scale(currentDpiScale.DpiScaleX, currentDpiScale.DpiScaleY);
                 }
                 else


### PR DESCRIPTION
Fixes Issue https://github.com/dotnet/wpf/issues/6829

